### PR TITLE
Revert "Revert "msm: vidc: cache-flush encoder output buffers after a…

### DIFF
--- a/drivers/video/msm/vidc/common/enc/venc_internal.c
+++ b/drivers/video/msm/vidc/common/enc/venc_internal.c
@@ -1620,7 +1620,12 @@ u32 vid_enc_set_buffer(struct video_client_ctx *client_ctx,
 	enum vcd_buffer_type vcd_buffer_t = VCD_BUFFER_INPUT;
 	enum buffer_dir dir_buffer = BUFFER_TYPE_INPUT;
 	u32 vcd_status = VCD_ERR_FAIL;
-	unsigned long kernel_vaddr, length = 0;
+	unsigned long kernel_vaddr, length, user_vaddr, phy_addr = 0;
+	int pmem_fd = 0;
+	struct ion_handle *buff_handle = NULL;
+	u32 ion_flag = 0;
+	struct file *file = NULL;
+	s32 buffer_index = 0;
 
 	if (!client_ctx || !buffer_info)
 		return false;
@@ -1641,6 +1646,38 @@ u32 vid_enc_set_buffer(struct video_client_ctx *client_ctx,
 		    __func__, buffer_info->pbuffer);
 		return false;
 	}
+
+	/*
+	* Flush output buffers explcitly once, during registration. This ensures
+	* any pending CPU writes (if cleared after allocation) are
+	* committed right away, or else this may get flushed _after_
+	* the hardware has written bitstream. rare bug, but can happen !
+	*/
+	if (buffer == VEN_BUFFER_TYPE_OUTPUT) {
+		user_vaddr = (unsigned long)buffer_info->pbuffer;
+		if (!vidc_lookup_addr_table(client_ctx, BUFFER_TYPE_OUTPUT,
+					true, &user_vaddr, &kernel_vaddr,
+					&phy_addr, &pmem_fd, &file,
+					&buffer_index)) {
+			ERR("%s(): vidc_lookup_addr_table failed\n",
+			__func__);
+			return false;
+		}
+
+		ion_flag = vidc_get_fd_info(client_ctx, BUFFER_TYPE_OUTPUT,
+				buffer_info->fd, kernel_vaddr, buffer_index,
+				&buff_handle);
+
+		if (ion_flag == ION_FLAG_CACHED && buff_handle) {
+			msm_ion_do_cache_op(
+					client_ctx->user_ion_client,
+					buff_handle,
+					NULL,
+					(unsigned long) length,
+					ION_IOC_INV_CACHES);
+		}
+	}
+
 
 	vcd_status = vcd_set_buffer(client_ctx->vcd_handle,
 				    vcd_buffer_t, (u8 *) kernel_vaddr,


### PR DESCRIPTION
…lloc""

This reverts commit 6c851fea2add8e2a32772e0df431e3469f16f9db.

mako is no longer using the same tree, so this change shouldn't pose
an issue anymore.

Change-Id: I511f04cb4b1a5466afc835ae9bde209afd68ecee